### PR TITLE
fix styled listbox name in autocomplete

### DIFF
--- a/components/core/Autocomplete/Autocomplete.tsx
+++ b/components/core/Autocomplete/Autocomplete.tsx
@@ -75,7 +75,7 @@ const StyledLoader = styled.div`
   }
 `;
 
-const StyledBoxList = styled.div`
+const StyledListbox = styled.div`
   display: none;
   position: absolute;
   box-sizing: border-box;
@@ -261,7 +261,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
         withSearchIcon={withSearchIcon}
         className={inputClassName}
       />
-      <StyledBoxList
+      <StyledListbox
         role="listbox"
         ref={listRef}
         onBlur={handleListBlur}
@@ -304,7 +304,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
             )}
           </StyledList>
         )}
-      </StyledBoxList>
+      </StyledListbox>
     </StyledAutocomplete>
   );
 };


### PR DESCRIPTION
## Details of PR

This code has changed because styled listbox name has been fixed in autocomplete

## Checklist

If any of the following are not checked please add a reason below each one as to why.

PR Setup

- [x] Correct labels added

Work Complete:

- [x] Acceptance criteria has been met and this PR
- [ ] Cypress/Jest tests have been written or updated
- [ ] Component has been added or updated to/for Storybook
