### PR TITLE
dropdown - update clearable by styled-component, add icon and label knob

### DIFF
--- a/components/Finder/Finder.tsx
+++ b/components/Finder/Finder.tsx
@@ -151,17 +151,15 @@ const Finder: React.FC<FinderProps> = ({ className }) => {
       <StyledSpacer />
       <StyledDropdownsWrapper>
         <StyledDropdown
-          withIcon="near_me"
+          icon="near_me"
           labelTxt="Select any location"
           list={LOCATIONS}
-          clearable={true}
           onSelect={(id: number) => console.log(id)}
         />
         <StyledDropdown
-          withIcon="restaurant"
+          icon="restaurant"
           labelTxt="Select any cuisine"
           list={CUISINES}
-          clearable={true}
           onSelect={(id: number) => console.log(id)}
         />
       </StyledDropdownsWrapper>

--- a/components/Finder/__tests__/__snapshots__/finder.spec.tsx.snap
+++ b/components/Finder/__tests__/__snapshots__/finder.spec.tsx.snap
@@ -228,24 +228,20 @@ exports[`Component: Finder should render 1`] = `
   color: #D48C24;
 }
 
-.c20:not(.clearable) i:last-of-type {
-  position: absolute;
-  z-index: 1;
-  top: 14px;
-  right: 7px;
-  font-size: 1.7rem;
-}
-
-.c20.clearable {
-  background-color: #FDF3E5;
-}
-
 .c20:hover {
   background-color: #FDF3E5;
 }
 
 .c20:focus {
   background-color: #FDF3E5;
+}
+
+.c20 i:last-of-type {
+  position: absolute;
+  z-index: 1;
+  top: 14px;
+  right: 7px;
+  font-size: 1.7rem;
 }
 
 .c21 {

--- a/components/Header/__tests__/__snapshots__/header.spec.tsx.snap
+++ b/components/Header/__tests__/__snapshots__/header.spec.tsx.snap
@@ -400,24 +400,20 @@ exports[`Component: Header should render extended Header 1`] = `
   color: #D48C24;
 }
 
-.c26:not(.clearable) i:last-of-type {
-  position: absolute;
-  z-index: 1;
-  top: 14px;
-  right: 7px;
-  font-size: 1.7rem;
-}
-
-.c26.clearable {
-  background-color: #FDF3E5;
-}
-
 .c26:hover {
   background-color: #FDF3E5;
 }
 
 .c26:focus {
   background-color: #FDF3E5;
+}
+
+.c26 i:last-of-type {
+  position: absolute;
+  z-index: 1;
+  top: 14px;
+  right: 7px;
+  font-size: 1.7rem;
 }
 
 .c27 {

--- a/components/core/Dropdown/Dropdown.tsx
+++ b/components/core/Dropdown/Dropdown.tsx
@@ -1,7 +1,6 @@
 import React, {
   useState,
   useRef,
-  useLayoutEffect,
   useEffect,
   useReducer,
   Dispatch,
@@ -18,9 +17,8 @@ type ListItemTypeWithIsActive = ListItemType & { isActive: boolean };
 
 type DropdownProps = {
   className?: string;
-  withIcon?: string;
+  icon?: string;
   labelTxt: string;
-  clearable?: boolean;
   list: ListItemType[];
   onSelect: (id: number) => void;
   onFocus?: (event: React.FocusEvent) => void;
@@ -47,7 +45,7 @@ const StyledLabel = styled.div`
   cursor: pointer;
 `;
 
-const StyledLabelButton = styled.button`
+const StyledLabelButton = styled.button<{ clearable: boolean }>`
   width: 100%;
   height: 55px;
   background-color: ${(props) => props.theme.palette.LIGHT_MAX};
@@ -71,26 +69,28 @@ const StyledLabelButton = styled.button`
       color: ${(props) => props.theme.palette.PRIMARY_DARK};
     }
   }
-  &:not(.clearable) {
-    i {
-      &:last-of-type {
-        position: absolute;
-        z-index: 1;
-        top: 14px;
-        right: 7px;
-        font-size: 1.7rem;
-      }
-    }
-  }
-  &.clearable {
-    background-color: ${(props) => props.theme.palette.PRIMARY_LIGHT};
-  }
   &:hover {
     background-color: ${(props) => props.theme.palette.PRIMARY_LIGHT};
   }
   &:focus {
     background-color: ${(props) => props.theme.palette.PRIMARY_LIGHT};
   }
+
+  ${(props) => {
+    if (props.clearable) {
+      return `background-color: ${props.theme.palette.PRIMARY_LIGHT}`;
+    } else {
+      return `i {
+        &:last-of-type {
+          position: absolute;
+          z-index: 1;
+          top: 14px;
+          right: 7px;
+          font-size: 1.7rem;
+        }
+      }`;
+    }
+  }}
 `;
 
 const StyledListbox = styled.div`
@@ -206,10 +206,9 @@ const listReducer = (list: ListItemType[], action: ListAction) => {
 
 const Dropdown: React.FC<DropdownProps> = ({
   className,
-  withIcon,
+  icon,
   labelTxt,
   list,
-  clearable,
   onSelect,
   onFocus,
   onBlur,
@@ -225,21 +224,21 @@ const Dropdown: React.FC<DropdownProps> = ({
   const listRef = useRef<HTMLDivElement>(null);
   const [currentLabelTxt, setCurrentLabelTxt] = useState(labelTxt);
   const [selectedId, setSelectedId] = useState(0);
-  const [labelButtonClassName, setLabelButtonClassName] = useState('');
+  const [isClearable, setIsClearable] = useState(false);
   const [listClassName, setListClassName] = useState('');
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (listClassName === 'active') {
       listRef.current?.focus();
     }
   }, [listClassName]);
 
   useEffect(() => {
-    if (!selectedId) {
-      setLabelButtonClassName('');
-      setCurrentLabelTxt(labelTxt);
+    if (selectedId) {
+      setIsClearable(true);
     } else {
-      setLabelButtonClassName('clearable');
+      setIsClearable(false);
+      setCurrentLabelTxt(labelTxt);
     }
   }, [selectedId, labelTxt]);
 
@@ -267,21 +266,21 @@ const Dropdown: React.FC<DropdownProps> = ({
       <StyledLabel>
         <StyledLabelButton
           type="button"
+          clearable={isClearable}
           onClick={(event: React.MouseEvent<HTMLElement>) => {
             event.preventDefault();
             setListClassName('active');
           }}
-          className={labelButtonClassName}
         >
-          {withIcon && (
+          {icon && (
             <i data-testid={'label-icon'} className="material-icons">
-              {withIcon}
+              {icon}
             </i>
           )}
           <span>{currentLabelTxt}</span>
           {!selectedId && <i className="material-icons">arrow_drop_down</i>}
         </StyledLabelButton>
-        {clearable && selectedId > 0 && (
+        {selectedId > 0 && (
           <StyledClearButton
             type="button"
             onClick={(event: React.MouseEvent<HTMLElement>) => {

--- a/components/core/Dropdown/__mocks__/dropdown.mocks.ts
+++ b/components/core/Dropdown/__mocks__/dropdown.mocks.ts
@@ -21,8 +21,15 @@ const LIST_MOCK = [
   },
 ];
 
+export const ICON_OPTIONS = {
+  label: 'label',
+  location: 'near_me',
+  cuisine: 'restaurant',
+  none: '',
+};
+
 export const DROPDOWN_PROPS_MOCK = {
-  withIcon: 'label',
+  icon: 'label',
   labelTxt: 'Select any option',
   list: LIST_MOCK,
   onSelect: () => {},

--- a/components/core/Dropdown/__stories__/dropdown.story.tsx
+++ b/components/core/Dropdown/__stories__/dropdown.story.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 
 import Dropdown from '../Dropdown';
 
-import { DROPDOWN_PROPS_MOCK } from '../__mocks__/dropdown.mocks';
+import { DROPDOWN_PROPS_MOCK, ICON_OPTIONS } from '../__mocks__/dropdown.mocks';
 
 const stories = storiesOf('Dropdown', module);
 
 stories.add('Dropdown', () => (
   <Dropdown
     {...DROPDOWN_PROPS_MOCK}
-    clearable={boolean('clearable', true)}
+    labelTxt={text('label text', DROPDOWN_PROPS_MOCK.labelTxt)}
+    icon={select('Icon', ICON_OPTIONS, DROPDOWN_PROPS_MOCK.icon)}
     onFocus={action('dropdown: on focus event')}
     onBlur={action('dropdown: on blur event')}
     onSelect={action('dropdown: on select option')}

--- a/components/core/Dropdown/__tests__/__snapshots__/dropdown.spec.tsx.snap
+++ b/components/core/Dropdown/__tests__/__snapshots__/dropdown.spec.tsx.snap
@@ -50,24 +50,20 @@ exports[`Component: Dropdown should render 1`] = `
   color: #D48C24;
 }
 
-.c2:not(.clearable) i:last-of-type {
-  position: absolute;
-  z-index: 1;
-  top: 14px;
-  right: 7px;
-  font-size: 1.7rem;
-}
-
-.c2.clearable {
-  background-color: #FDF3E5;
-}
-
 .c2:hover {
   background-color: #FDF3E5;
 }
 
 .c2:focus {
   background-color: #FDF3E5;
+}
+
+.c2 i:last-of-type {
+  position: absolute;
+  z-index: 1;
+  top: 14px;
+  right: 7px;
+  font-size: 1.7rem;
 }
 
 .c3 {
@@ -326,6 +322,7 @@ exports[`Component: Dropdown should render with clearable option 1`] = `
   -webkit-user-select: none;
   -ms-user-select: none;
   -moz-user-select: none;
+  background-color: #FDF3E5;
 }
 
 .c2 i:first-of-type {
@@ -333,18 +330,6 @@ exports[`Component: Dropdown should render with clearable option 1`] = `
   margin-left: 5px;
   margin-right: 10px;
   color: #D48C24;
-}
-
-.c2:not(.clearable) i:last-of-type {
-  position: absolute;
-  z-index: 1;
-  top: 14px;
-  right: 7px;
-  font-size: 1.7rem;
-}
-
-.c2.clearable {
-  background-color: #FDF3E5;
 }
 
 .c2:hover {
@@ -509,7 +494,7 @@ exports[`Component: Dropdown should render with clearable option 1`] = `
     class="c1"
   >
     <button
-      class="c2 clearable"
+      class="c2"
       type="button"
     >
       <i


### PR DESCRIPTION
## Details of PR

This code has changed because dropdown component has been updated. From now, clearable functionality is handled by Styled-components and label text editable and icon select have been added as knobs in the regarding story.

## Checklist

If any of the following are not checked please add a reason below each one as to why.

PR Setup

- [x] Correct labels added

Work Complete:

- [x] Acceptance criteria has been met and this PR
- [x] Cypress/Jest tests have been written or updated
- [x] Component has been added or updated to/for Storybook
