### PR TITLE
disable dropdown and autocomplete on request

### DIFF
--- a/components/core/Autocomplete/Autocomplete.tsx
+++ b/components/core/Autocomplete/Autocomplete.tsx
@@ -18,10 +18,11 @@ import {
 import { Restaurant, CardType } from '../../../helpers/types';
 
 export type AutocompleteProps = {
-  className?: string;
   hasSearchIcon?: boolean;
   suggestions: Restaurant[];
   loading: boolean;
+  className?: string;
+  disabled: boolean;
   fetchSuggestions: (search: string) => void;
   selectSuggestion: (id: string, name: string) => void;
 };
@@ -33,6 +34,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   loading,
   hasSearchIcon,
   className,
+  disabled,
 }) => {
   const blurDelay = useRef(0);
   const isSuggestable = useRef(true);
@@ -83,7 +85,11 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
     (isListboxFocused && value.length < 3);
 
   return (
-    <StyledAutocomplete data-testid="autocomplete" className={className}>
+    <StyledAutocomplete
+      data-testid="autocomplete"
+      className={className}
+      disabled={disabled}
+    >
       <StyledInput
         type="text"
         hasBorderBottomRadius={hasBorderBottomRadius}

--- a/components/core/Autocomplete/AutocompleteMobile.tsx
+++ b/components/core/Autocomplete/AutocompleteMobile.tsx
@@ -25,10 +25,11 @@ import {
 import { Restaurant, CardType } from '../../../helpers/types';
 
 export type AutocompleteMobileProps = {
-  className?: string;
   hasSearchIcon?: boolean;
   suggestions: Restaurant[];
   loading: boolean;
+  className?: string;
+  disabled: boolean;
   fetchSuggestions: (search: string) => void;
   selectSuggestion: (id: string, name: string) => void;
 };
@@ -40,6 +41,7 @@ export const AutocompleteMobile: React.FC<AutocompleteMobileProps> = ({
   loading,
   hasSearchIcon,
   className,
+  disabled,
 }) => {
   const listboxWrapperRef = useRef<HTMLDivElement>(null);
   const isSuggestable = useRef(true);
@@ -102,7 +104,11 @@ export const AutocompleteMobile: React.FC<AutocompleteMobileProps> = ({
   };
 
   return (
-    <StyledAutocompleteMobile data-testid="autocomplete" className={className}>
+    <StyledAutocompleteMobile
+      data-testid="autocomplete"
+      className={className}
+      disabled={disabled}
+    >
       <>
         <StyledLabel data-testid="label">
           <StyledLabelButton

--- a/components/core/Autocomplete/__mocks__/autocomplete.mocks.ts
+++ b/components/core/Autocomplete/__mocks__/autocomplete.mocks.ts
@@ -34,4 +34,5 @@ export const AUTOCOMPLETE_PROPS_MOCK = {
   selectSuggestion: () => {},
   loading: false,
   hasSearchIcon: true,
+  disabled: false,
 };

--- a/components/core/Autocomplete/__stories__/autocomplete.story.tsx
+++ b/components/core/Autocomplete/__stories__/autocomplete.story.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import { Autocomplete } from '../Autocomplete';
 import { AutocompleteMobile } from '../AutocompleteMobile';
@@ -18,6 +18,7 @@ stories.add('Autocomplete', () => (
   <Autocomplete
     {...AUTOCOMPLETE_PROPS_MOCK}
     loading={boolean('loading', false)}
+    disabled={boolean('disabled', false)}
     suggestions={SUGGESTIONS_MOCK}
     fetchSuggestions={action('autocomplete: fetch suggestions')}
   />
@@ -27,6 +28,7 @@ stories.add('AutocompleteMobile', () => (
   <AutocompleteMobile
     {...AUTOCOMPLETE_PROPS_MOCK}
     loading={boolean('loading', false)}
+    disabled={boolean('disabled', false)}
     suggestions={SUGGESTIONS_MOCK}
     fetchSuggestions={action('autocomplete: fetch suggestions')}
   />

--- a/components/core/Autocomplete/__tests__/autocomplete.spec.tsx
+++ b/components/core/Autocomplete/__tests__/autocomplete.spec.tsx
@@ -91,4 +91,17 @@ describe('Component: Autocomplete', () => {
 
     expect(handleSelectSuggestion).toHaveBeenCalled();
   });
+
+  it('should be disabled', () => {
+    const AUTOCOMPLETE_PROPS_MOCK_DISABLED = {
+      ...AUTOCOMPLETE_PROPS_MOCK,
+      disabled: true,
+    };
+    const { container } = render(
+      renderWithTheme(<Autocomplete {...AUTOCOMPLETE_PROPS_MOCK_DISABLED} />),
+    );
+    const autocomplete = container.firstChild as HTMLDivElement;
+
+    expect(autocomplete).toHaveStyleRule('pointer-events', 'none');
+  });
 });

--- a/components/core/Autocomplete/__tests__/autocompleteMobile.spec.tsx
+++ b/components/core/Autocomplete/__tests__/autocompleteMobile.spec.tsx
@@ -108,4 +108,19 @@ describe('Component: AutocompleteMobile', () => {
 
     expect(handleSelectSuggestion).toHaveBeenCalled();
   });
+
+  it('should be disabled', () => {
+    const AUTOCOMPLETE_PROPS_MOCK_DISABLED = {
+      ...AUTOCOMPLETE_PROPS_MOCK,
+      disabled: true,
+    };
+    const { container } = render(
+      renderWithTheme(
+        <AutocompleteMobile {...AUTOCOMPLETE_PROPS_MOCK_DISABLED} />,
+      ),
+    );
+    const autocomplete = container.firstChild as HTMLDivElement;
+
+    expect(autocomplete).toHaveStyleRule('pointer-events', 'none');
+  });
 });

--- a/components/core/Autocomplete/styles/autocomplete.tsx
+++ b/components/core/Autocomplete/styles/autocomplete.tsx
@@ -3,12 +3,13 @@ import styled from 'styled-components';
 import { Input } from '../../Input/Input';
 import { Loader } from '../../Loader/Loader';
 
-export const StyledAutocomplete = styled.div`
+export const StyledAutocomplete = styled.div<{ disabled: boolean }>`
   width: 100%;
   max-width: 550px;
   height: 55px;
   position: relative;
   cursor: pointer;
+  pointer-events: ${({ disabled }) => disabled && 'none'};
 `;
 
 export const StyledInput = styled(Input)<{ hasBorderBottomRadius: boolean }>`

--- a/components/core/Autocomplete/styles/autocompleteMobile.tsx
+++ b/components/core/Autocomplete/styles/autocompleteMobile.tsx
@@ -4,10 +4,11 @@ import { Input } from '../../Input/Input';
 import { Loader } from '../../Loader/Loader';
 import { BlockTitle } from '../../BlockTitle/BlockTitle';
 
-export const StyledAutocompleteMobile = styled.div`
+export const StyledAutocompleteMobile = styled.div<{ disabled: boolean }>`
   width: 100%;
   max-width: 550px;
   height: 100%;
+  pointer-events: ${({ disabled }) => disabled && 'none'};
 `;
 
 export const StyledLabel = styled.div`

--- a/components/core/Dropdown/Dropdown.tsx
+++ b/components/core/Dropdown/Dropdown.tsx
@@ -32,6 +32,7 @@ type DropdownProps = {
   icon?: string;
   labelTxt: string;
   list: ListItem[];
+  disabled: boolean;
   onSelect: (path: string) => void;
   onClear: () => void;
   onFocus?: (event: React.FocusEvent) => void;
@@ -56,10 +57,11 @@ const listReducer = (list: ListItem[], action: ListAction) => {
 };
 
 export const Dropdown: React.FC<DropdownProps> = ({
-  className,
   icon,
   labelTxt,
   list,
+  className,
+  disabled,
   onSelect,
   onClear,
   onFocus,
@@ -126,7 +128,11 @@ export const Dropdown: React.FC<DropdownProps> = ({
   };
 
   return (
-    <StyledDropdown data-testid="dropdown" className={className}>
+    <StyledDropdown
+      data-testid="dropdown"
+      className={className}
+      disabled={disabled}
+    >
       <StyledLabel>
         <StyledLabelButton
           type="button"

--- a/components/core/Dropdown/__mocks__/dropdown.mocks.ts
+++ b/components/core/Dropdown/__mocks__/dropdown.mocks.ts
@@ -37,6 +37,7 @@ export const DROPDOWN_PROPS_MOCK = {
   icon: 'label',
   labelTxt: 'Select any option',
   list: LIST_MOCK,
+  disabled: false,
   onSelect: () => {},
   onClear: () => {},
 };

--- a/components/core/Dropdown/__stories__/dropdown.story.tsx
+++ b/components/core/Dropdown/__stories__/dropdown.story.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
+import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import { text, select } from '@storybook/addon-knobs';
 
 import { Dropdown } from '../Dropdown';
 
@@ -15,6 +15,7 @@ stories.add('Dropdown', () => (
     {...DROPDOWN_PROPS_MOCK}
     labelTxt={text('label text', DROPDOWN_PROPS_MOCK.labelTxt)}
     icon={select('icon', ICON_OPTIONS, DROPDOWN_PROPS_MOCK.icon)}
+    disabled={boolean('disabled', false)}
     onFocus={action('dropdown: on focus event')}
     onBlur={action('dropdown: on blur event')}
     onSelect={action('dropdown: on select option')}

--- a/components/core/Dropdown/__tests__/dropdown.spec.tsx
+++ b/components/core/Dropdown/__tests__/dropdown.spec.tsx
@@ -134,4 +134,17 @@ describe('Component: Dropdown', () => {
     expect(labelButton.nextElementSibling).toBeTruthy();
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('should be disabled', () => {
+    const DROPDOWN_PROPS_MOCK_DISABLED = {
+      ...DROPDOWN_PROPS_MOCK,
+      disabled: true,
+    };
+    const { container } = render(
+      renderWithTheme(<Dropdown {...DROPDOWN_PROPS_MOCK_DISABLED} />),
+    );
+    const dropdown = container.firstChild as HTMLDivElement;
+
+    expect(dropdown).toHaveStyleRule('pointer-events', 'none');
+  });
 });

--- a/components/core/Dropdown/styles.tsx
+++ b/components/core/Dropdown/styles.tsx
@@ -2,11 +2,12 @@ import styled, { css } from 'styled-components';
 
 import { BlockTitle } from '../BlockTitle/BlockTitle';
 
-export const StyledDropdown = styled.div`
+export const StyledDropdown = styled.div<{ disabled: boolean }>`
   width: 100%;
   max-width: 550px;
   height: 100%;
   position: initial;
+  pointer-events: ${({ disabled }) => disabled && 'none'};
   @media only screen and (min-width: 768px) {
     height: 55px;
     position: relative;

--- a/components/ui/Finder/Finder.tsx
+++ b/components/ui/Finder/Finder.tsx
@@ -120,6 +120,7 @@ export const Finder: React.FC<FinderProps> = ({ className }) => {
           suggestions={suggestions}
           fetchSuggestions={fetchSuggestions}
           selectSuggestion={selectSuggestion}
+          disabled={isButtonLoading}
           loading={isAutocompleteLoading}
           hasSearchIcon={true}
         />
@@ -128,6 +129,7 @@ export const Finder: React.FC<FinderProps> = ({ className }) => {
           suggestions={suggestions}
           fetchSuggestions={fetchSuggestions}
           selectSuggestion={selectSuggestion}
+          disabled={isButtonLoading}
           loading={isAutocompleteLoading}
           hasSearchIcon={true}
         />
@@ -138,6 +140,7 @@ export const Finder: React.FC<FinderProps> = ({ className }) => {
           icon="near_me"
           labelTxt="Select any location"
           list={LOCATIONS}
+          disabled={isButtonLoading}
           onSelect={(path: string) => setCurrentLocationPath(path)}
           onClear={() => setCurrentLocationPath('dublin')}
         />
@@ -145,6 +148,7 @@ export const Finder: React.FC<FinderProps> = ({ className }) => {
           icon="restaurant"
           labelTxt="Select any cuisine"
           list={CUISINES}
+          disabled={isButtonLoading}
           onSelect={(path: string) => setCurrentCuisinePath(path)}
           onClear={() => setCurrentCuisinePath('any-food')}
         />


### PR DESCRIPTION
## Details of PR

This code has changed because autocomplete, autocomplete mobile and dropdown components have been disabled on finder request

## Checklist

If any of the following are not checked please add a reason below each one as to why.

PR Setup

- [x] Correct labels added

Work Complete:

- [x] Acceptance criteria has been met and this PR
- [x] Cypress/Jest tests have been written or updated
- [x] Component has been added or updated to/for Storybook
