### PR TITLE
fix establishment and reviews when they are received as blank

### DIFF
--- a/components/pages/DetailPage/DetailPage.tsx
+++ b/components/pages/DetailPage/DetailPage.tsx
@@ -36,7 +36,7 @@ import { DETAIL_GENERIC_SRC, DEFAULT_TEXT_LOADING } from '@/store/statics';
 import { RestaurantDetail, Restaurant, Review, Timming } from '../types';
 
 type DetailPageProps = {
-  data: RestaurantDetail;
+  detail: RestaurantDetail;
   reviews: Review[] | null;
   isFavorite: boolean;
   relatedRestaurants: Restaurant[];
@@ -68,7 +68,7 @@ export const getMapSrc = (name: string, location: string) => {
 };
 
 const DetailPage: React.FC<DetailPageProps> = ({
-  data: {
+  detail: {
     imgSrc,
     name,
     location,
@@ -179,12 +179,12 @@ const DetailPage: React.FC<DetailPageProps> = ({
                   <Highlights highlights={highlights} />
                 </StyledSectionBlock>
               </div>
-              <div className="cell small-12">
-                <StyledSectionBlock>
-                  <StyledReviewsWrapper>
-                    <StyledBlockTitle text="Reviews" />
-                    {reviews &&
-                      reviews.map((review) => (
+              {reviews && reviews.length > 0 && (
+                <div className="cell small-12">
+                  <StyledSectionBlock>
+                    <StyledReviewsWrapper>
+                      <StyledBlockTitle text="Reviews" />
+                      {reviews.map((review) => (
                         <ReviewCard
                           key={review.id}
                           userImgSrc={review.userImgSrc}
@@ -194,9 +194,10 @@ const DetailPage: React.FC<DetailPageProps> = ({
                           text={review.text}
                         />
                       ))}
-                  </StyledReviewsWrapper>
-                </StyledSectionBlock>
-              </div>
+                    </StyledReviewsWrapper>
+                  </StyledSectionBlock>
+                </div>
+              )}
             </div>
             <div className="cell small-12 large-5">
               <StyledAddressWrapper className="paper">

--- a/pages/detail/[id]/[name].tsx
+++ b/pages/detail/[id]/[name].tsx
@@ -79,8 +79,8 @@ const selectReviews = (rawReviews: RawReview[]) => (
   formattedFuntion: (rawReview: RawReview) => Review,
 ) => rawReviews.map((rawReview) => formattedFuntion(rawReview));
 
-const Detail: NextPage<DetailProps> = ({ data, reviewsData, id }) => {
-  if (!data) {
+const Detail: NextPage<DetailProps> = ({ detail, reviews, id }) => {
+  if (!detail) {
     return <ErrorPage />;
   }
 
@@ -100,11 +100,11 @@ const Detail: NextPage<DetailProps> = ({ data, reviewsData, id }) => {
   }, [id]);
 
   const handleSaveButton = (action: string) => {
-    const favorite = getRefinedRestaurant(id, data);
+    const favorite = getRefinedRestaurant(id, detail);
     dispatch(action === 'save' ? addFavorite(favorite) : deleteFavorite(id));
   };
 
-  const { name, imgSrc } = data;
+  const { name, imgSrc } = detail;
   const detailBreadcrumbs = {
     text: name,
     route: '/detail/[id]/[name]',
@@ -119,8 +119,8 @@ const Detail: NextPage<DetailProps> = ({ data, reviewsData, id }) => {
         <link rel="preload" as="image" href={imgSrc} />
       </Head>
       <DynamicDetailPage
-        data={data}
-        reviews={reviewsData}
+        detail={detail}
+        reviews={reviews}
         isFavorite={isFavorite}
         relatedRestaurants={relatedRestaurants}
         onClickSaveButton={handleSaveButton}
@@ -138,11 +138,11 @@ export const getServerSideProps = async ({
   const { rawRestaurantDetail, status } = await getRestaurant(id);
   const { rawReviews, status: reviewsStatus } = await getReviews(id);
 
-  let filteredData: RestaurantDetail | null = null;
-  let currentReviewsData: Review[] | null = null;
+  let formattedRestaurantDetail: RestaurantDetail | null = null;
+  let formattedReviews: Review[] | null = null;
 
   if (status === 200) {
-    filteredData = {
+    formattedRestaurantDetail = {
       imgSrc: rawRestaurantDetail.featured_image,
       thumbSrc: rawRestaurantDetail.thumb,
       name: rawRestaurantDetail.name,
@@ -152,7 +152,7 @@ export const getServerSideProps = async ({
       rating: rawRestaurantDetail.user_rating.aggregate_rating,
       votes: rawRestaurantDetail.user_rating.votes,
       average: rawRestaurantDetail.average_cost_for_two,
-      establishment: rawRestaurantDetail.establishment[0],
+      establishment: rawRestaurantDetail.establishment[0] || '',
       highlights: rawRestaurantDetail.highlights,
       phone: rawRestaurantDetail.phone_numbers,
       address: rawRestaurantDetail.location.address,
@@ -160,14 +160,14 @@ export const getServerSideProps = async ({
   }
 
   if (reviewsStatus === 200) {
-    const reviews = selectReviews(rawReviews);
-    currentReviewsData = reviews(getRefinedReview);
+    const currentReviews = selectReviews(rawReviews);
+    formattedReviews = currentReviews(getRefinedReview);
   }
 
   return {
     props: {
-      data: filteredData,
-      reviewsData: currentReviewsData,
+      detail: formattedRestaurantDetail,
+      reviews: formattedReviews,
       id,
     },
   };


### PR DESCRIPTION
## Details of PR

This code has changed because a fix has been implemented when the establishment and reviews data are blank from BE

## Checklist

If any of the following are not checked please add a reason below each one as to why.

PR Setup

- [x] Correct labels added

Work Complete:

- [x] Acceptance criteria has been met and this PR
- [ ] Cypress/Jest tests have been written or updated
- [ ] Component has been added or updated to/for Storybook
